### PR TITLE
Updated gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 test*
+test_*


### PR DESCRIPTION
.gitignore now discard any file generated as 'test' as well as 'test_' with any character after the '_'.